### PR TITLE
Parallelize and add more wheel builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,13 +22,11 @@ jobs:
         with:
           python-version: 3.x
 
-      - run: pip install cibuildwheel==2.17.0
-
-      - name: Patch setup.py with python_requires
-        run: sed -i'' -e "s/setup(/setup(python_requires='$PYTHON_REQUIRES',/" setup.py
-        working-directory: ${{ env.WORKING_DIRECTORY }}
+      - run: pip install cibuildwheel==2.17.0  # sync version with pypa/cibuildwheel below
 
       - id: set-matrix
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.7'  # it is missing in setup.py and needed to determine which wheels to build
         run: |
           MATRIX_INCLUDE=$(
             {
@@ -76,14 +74,14 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
 
-    - uses: pypa/cibuildwheel@v2.17.0
+    - uses: pypa/cibuildwheel@v2.17.0  # sync version with pip install cibuildwheel above
       with:
         only: ${{ matrix.only }}
         package-dir: ${{ env.WORKING_DIRECTORY }}
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install cmake
-        CIBW_TEST_COMMAND: python -c "import dlib" # smoketest
+        CIBW_TEST_COMMAND: python -c "import dlib"
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,58 +3,77 @@ name: Build
 on: [push]
 
 jobs:
+  build_wheels_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - run: pip install cibuildwheel==2.17.0
+      - id: set-matrix
+        run: |
+          MATRIX_INCLUDE=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    needs: build_wheels_matrix
     runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.only }}
+
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include: ${{ fromJson(needs.build_wheels_matrix.outputs.include) }}
+
+    defaults:
+      run:
+        shell: bash
+
     env:
       REPO_DIR: 'dlib'
       BUILD_COMMIT: 'v19.24.2'
       DLIB_BIN_VERSION: '19.24.2'
-      CIBUILDWHEEL_VERSION: '2.17.0'
-      CIBW_BEFORE_BUILD: 'pip install cmake'
-      CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-* cp311-*'
-      CIBW_SKIP: '*musllinux*'
-      CIBW_ARCHS: 'auto64'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-      - name: Checkout submodules
-        shell: bash
-        run: |
-          git submodule update --init --recursive
-          git -C dlib checkout $BUILD_COMMIT
+    - name: Checkout submodules
+      run: |
+        git submodule update --init --recursive
+        git -C dlib checkout $BUILD_COMMIT
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+    - name: Fix setup.py
+      run: |
+        sed -i'' -e "s/name='dlib'/name='dlib-bin'/" $REPO_DIR/setup.py
+        sed -i'' -e "s/version=read_version_from_cmakelists('dlib\/CMakeLists.txt')/version='$DLIB_BIN_VERSION'/" $REPO_DIR/setup.py
+        sed -i'' -e "s/url='https:\/\/github\.com\/davisking\/dlib'/url='https:\/\/github\.com\/alesanfra\/dlib-wheels'/" $REPO_DIR/setup.py
+        sed -i'' -e "s/_cmake_extra_options = \[\]/_cmake_extra_options = \['-DDLIB_NO_GUI_SUPPORT=ON'\]/" $REPO_DIR/setup.py
+          
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v3
 
-      - name: Fix setup.py
-        shell: bash
-        run: |
-          sed -i'' -e "s/name='dlib'/name='dlib-bin'/" $REPO_DIR/setup.py
-          sed -i'' -e "s/version=read_version_from_cmakelists('dlib\/CMakeLists.txt')/version='$DLIB_BIN_VERSION'/" $REPO_DIR/setup.py
-          sed -i'' -e "s/url='https:\/\/github\.com\/davisking\/dlib'/url='https:\/\/github\.com\/alesanfra\/dlib-wheels'/" $REPO_DIR/setup.py
-          sed -i'' -e "s/_cmake_extra_options = \[\]/_cmake_extra_options = \['-DDLIB_NO_GUI_SUPPORT=ON'\]/" $REPO_DIR/setup.py
+    - uses: pypa/cibuildwheel@v2.17.0
+      with:
+        only: ${{ matrix.only }}
+      env:
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_BEFORE_BUILD: pip install cmake
 
-      - name: Install cibuildwheel
-        shell: bash
-        run: python -m pip install cibuildwheel==$CIBUILDWHEEL_VERSION
-      
-      - name: Build wheels
-        shell: bash
-        run: python3 -m cibuildwheel $REPO_DIR --output-dir wheelhouse
-
-      - name: Save wheels
-        uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: wheelhouse/*.whl
+ 
   upload_pypi:
     needs: [build_wheels]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,7 @@ jobs:
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install cmake
-        CIBW_REPAIR_WHEEL_COMMAND_MACOS: '' # arm64 repair is complaining
+        CIBW_REPAIR_WHEEL_COMMAND_MACOS: 'delocate-wheel -w {dest_dir} -v {wheel}' # removed '--require-archs {delocate_archs}' from the default command, arm64 was complaining about the generated pybind so
         CIBW_TEST_COMMAND: python -c "import dlib" # smoketest
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,18 @@ jobs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: 3.x
+
       - run: pip install cibuildwheel==2.17.0
-      - run: sed -i'' -e "s/setup(/setup(python_requires='$PYTHON_REQUIRES',/" $REPO_DIR/setup.py
+
+      - name: Patch setup.py with python_requires
+        run: sed -i'' -e "s/setup(/setup(python_requires='$PYTHON_REQUIRES',/" $REPO_DIR/setup.py
+
       - id: set-matrix
         run: |
           MATRIX_INCLUDE=$(
@@ -47,10 +54,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
 
-    - name: Checkout submodules
+    - name: Checkout build commit
       run: |
-        git submodule update --init --recursive
         git -C dlib checkout $BUILD_COMMIT
 
     - name: Fix setup.py
@@ -71,9 +79,9 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install cmake
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-${{ matrix.only }}
         path: wheelhouse/*.whl
  
   upload_pypi:
@@ -82,10 +90,11 @@ jobs:
     # upload to PyPI on master
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
-          path: dist
+          path: dist/
+          pattern: dist-*
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,8 @@ jobs:
           MATRIX_INCLUDE=$(
             {
               cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-12"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
@@ -82,7 +83,6 @@ jobs:
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install cmake
-        CIBW_REPAIR_WHEEL_COMMAND_MACOS: 'delocate-wheel -w {dest_dir} -v {wheel}' # removed '--require-archs {delocate_archs}' from the default command, arm64 was complaining about the generated pybind so
         CIBW_TEST_COMMAND: python -c "import dlib" # smoketest
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
           MATRIX_INCLUDE=$(
             {
               cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-12"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-13"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-14"}' \
               && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,12 @@ name: Build
 
 on: [push]
 
+env:
+  REPO_DIR: 'dlib'
+  BUILD_COMMIT: 'v19.24.2'
+  DLIB_BIN_VERSION: '19.24.2'
+  PYTHON_REQUIRES: '>=3.7'
+
 jobs:
   build_wheels_matrix:
     runs-on: ubuntu-latest
@@ -13,6 +19,7 @@ jobs:
         with:
           python-version: "3.x"
       - run: pip install cibuildwheel==2.17.0
+      - run: sed -i'' -e "s/setup(/setup(python_requires='$PYTHON_REQUIRES',/" $REPO_DIR/setup.py
       - id: set-matrix
         run: |
           MATRIX_INCLUDE=$(
@@ -37,11 +44,6 @@ jobs:
     defaults:
       run:
         shell: bash
-
-    env:
-      REPO_DIR: 'dlib'
-      BUILD_COMMIT: 'v19.24.2'
-      DLIB_BIN_VERSION: '19.24.2'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
             {
               cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
               && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
+              && cibuildwheel --print-build-identifiers --platform windows --arch AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
@@ -82,6 +82,8 @@ jobs:
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install cmake
+        CIBW_REPAIR_WHEEL_COMMAND_MACOS: '' # arm64 repair is complaining
+        CIBW_TEST_COMMAND: python -c "import dlib" # smoketest
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
         submodules: true
 
     - name: Checkout build commit
-      run: git checkout $BUILD_COMMIT
+      run: git fetch --all && git checkout $BUILD_COMMIT
       working-directory: ${{ env.WORKING_DIRECTORY }}
 
     - name: Fix setup.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build
 on: [push]
 
 env:
-  REPO_DIR: 'dlib'
+  WORKING_DIRECTORY: 'dlib'
   BUILD_COMMIT: 'v19.24.2'
   DLIB_BIN_VERSION: '19.24.2'
   PYTHON_REQUIRES: '>=3.7'
@@ -25,7 +25,8 @@ jobs:
       - run: pip install cibuildwheel==2.17.0
 
       - name: Patch setup.py with python_requires
-        run: sed -i'' -e "s/setup(/setup(python_requires='$PYTHON_REQUIRES',/" $REPO_DIR/setup.py
+        run: sed -i'' -e "s/setup(/setup(python_requires='$PYTHON_REQUIRES',/" setup.py
+        working-directory: ${{ env.WORKING_DIRECTORY }}
 
       - id: set-matrix
         run: |
@@ -37,6 +38,7 @@ jobs:
             } | jq -sc
           )
           echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
+        working-directory: ${{ env.WORKING_DIRECTORY }}
 
   build_wheels:
     needs: build_wheels_matrix
@@ -58,15 +60,16 @@ jobs:
         submodules: true
 
     - name: Checkout build commit
-      run: |
-        git -C dlib checkout $BUILD_COMMIT
+      run: git checkout $BUILD_COMMIT
+      working-directory: ${{ env.WORKING_DIRECTORY }}
 
     - name: Fix setup.py
       run: |
-        sed -i'' -e "s/name='dlib'/name='dlib-bin'/" $REPO_DIR/setup.py
-        sed -i'' -e "s/version=read_version_from_cmakelists('dlib\/CMakeLists.txt')/version='$DLIB_BIN_VERSION'/" $REPO_DIR/setup.py
-        sed -i'' -e "s/url='https:\/\/github\.com\/davisking\/dlib'/url='https:\/\/github\.com\/alesanfra\/dlib-wheels'/" $REPO_DIR/setup.py
-        sed -i'' -e "s/_cmake_extra_options = \[\]/_cmake_extra_options = \['-DDLIB_NO_GUI_SUPPORT=ON'\]/" $REPO_DIR/setup.py
+        sed -i'' -e "s/name='dlib'/name='dlib-bin'/" setup.py
+        sed -i'' -e "s/version=read_version_from_cmakelists('dlib\/CMakeLists.txt')/version='$DLIB_BIN_VERSION'/" setup.py
+        sed -i'' -e "s/url='https:\/\/github\.com\/davisking\/dlib'/url='https:\/\/github\.com\/alesanfra\/dlib-wheels'/" setup.py
+        sed -i'' -e "s/_cmake_extra_options = \[\]/_cmake_extra_options = \['-DDLIB_NO_GUI_SUPPORT=ON'\]/" setup.py
+      working-directory: ${{ env.WORKING_DIRECTORY }}
           
     - name: Set up QEMU
       if: runner.os == 'Linux'
@@ -75,6 +78,7 @@ jobs:
     - uses: pypa/cibuildwheel@v2.17.0
       with:
         only: ${{ matrix.only }}
+        package-dir: ${{ env.WORKING_DIRECTORY }}
       env:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_BEFORE_BUILD: pip install cmake


### PR DESCRIPTION
linux-aarch64 makes up for almost 10% of all platforms ref https://github.com/giampaolo/psutil/pull/2103
> aarch64 has already surpassed windows in terms of downloads for this package. Oracle, Amazon, Google, and Microsoft are all offering aarch64 cloud instances at an undeniable price point compared to amd/intel, so the demand will undoubtedly only grow

Same goes for mac and their new arm chips. This PR ads arm64/aarch64 and alpine(musl) wheels.

Example run: https://github.com/ddelange/dlib-wheels/actions/runs/8555157171

- The first step generates a matrix of all wheel combinations (based on `python_requires` in setup.py, missing here so I added `CIBW_PROJECT_REQUIRES_PYTHON`)
- For each output wheel, one job is created and so the wheels build in maximum parallelization.
- Use native arm64 mac runners for the arm64 macos wheels

Analogous to https://github.com/vaexio/vaex/pull/2331, https://github.com/ahupp/python-magic/pull/294, https://github.com/MagicStack/asyncpg/pull/954