### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on master
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      id-token: write  # pypa/gh-action-pypi-publish
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -101,6 +103,3 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}
-          skip_existing: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,3 +103,5 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true


### PR DESCRIPTION
switch to [trusted publishing](https://docs.pypi.org/trusted-publishers/)

before merging, add this repo as trusted publisher to https://pypi.org/manage/project/dlib-bin/settings/publishing/